### PR TITLE
Remove -march=native compilation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project does not depend on any other library, except of course the standard
 
 ## Building and Running
 
-    g++ minbool.cpp -pedantic -Wall -Wextra -O3 -DNDEBUG -march=native -std=c++11 -o minbool
+    g++ minbool.cpp -pedantic -Wall -Wextra -O3 -DNDEBUG -std=c++11 -o minbool
     ./minbool
 
 ## Using the Simplifier


### PR DESCRIPTION
The readme provides a command with `-march=native` compilation option. This is not supported when building with Clang on Apple Silicon [with older versions of Clang](https://www.phoronix.com/news/LLVM-Clang-march-native-M1). 

```
➜  minbool git:(master) ✗ clang --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin22.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
➜  minbool git:(master) ✗ g++ minbool.cpp -pedantic -Wall -Wextra -O3 -DNDEBUG -march=native -std=c++11 -o minbool
clang: error: the clang compiler does not support '-march=native'
```

```
➜  minbool git:(master) ✗ /opt/homebrew/Cellar/llvm@12/12.0.1_1/bin/clang++ --version
Homebrew clang version 12.0.1
Target: arm64-apple-darwin22.1.0
Thread model: posix
InstalledDir: /opt/homebrew/Cellar/llvm@12/12.0.1_1/bin
➜  minbool git:(master) ✗ /opt/homebrew/Cellar/llvm@12/12.0.1_1/bin/clang++ minbool.cpp -pedantic -Wall -Wextra -O3 -DNDEBUG -march=native -std=c++11 -o minbool
clang-12: error: the clang compiler does not support '-march=native'
```